### PR TITLE
Fix: [Actions] AWS CLI v2 requires setting the encoding of payloads.

### DIFF
--- a/.github/workflows/reload_api.yaml
+++ b/.github/workflows/reload_api.yaml
@@ -8,12 +8,12 @@ on:
 jobs:
   reload:
     name: Reload API database
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Reload API database
       run: |
-        aws lambda invoke --region ${{ secrets.AWS_REGION }} --function-name "${{ secrets.API_FUNCTION_NAME }}" --payload='{"secret":"${{ secrets.API_RELOAD_SECRET }}"}' output.txt
+        aws lambda invoke --cli-binary-format raw-in-base64-out --region ${{ secrets.AWS_REGION }} --function-name "${{ secrets.API_FUNCTION_NAME }}" --payload='{"secret":"${{ secrets.API_RELOAD_SECRET }}"}' output.txt
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.API_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.API_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/reload_server.yaml
+++ b/.github/workflows/reload_server.yaml
@@ -8,12 +8,12 @@ on:
 jobs:
   reload:
     name: Reload server database
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Reload server database
       run: |
-        aws lambda invoke --region ${{ secrets.AWS_REGION }} --function-name "${{ secrets.SERVER_FUNCTION_NAME }}" --payload='{"secret":"${{ secrets.SERVER_RELOAD_SECRET }}"}' output.txt
+        aws lambda invoke --cli-binary-format raw-in-base64-out --region ${{ secrets.AWS_REGION }} --function-name "${{ secrets.SERVER_FUNCTION_NAME }}" --payload='{"secret":"${{ secrets.SERVER_RELOAD_SECRET }}"}' output.txt
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.SERVER_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.SERVER_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
AWS CLI v2 defaults to using base64-encoded payloads.

We want to continue using plain payloads, so the secret hider continues to work.